### PR TITLE
Allow mysql v7 cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,5 +14,5 @@ supports 'debian'
 supports 'ubuntu'
 
 depends 'build-essential'
-depends 'mysql', '~> 6.0'
+depends 'mysql', '>= 6.0'
 depends 'mariadb'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Nicolas Blanc'
 maintainer_email 'sinfomicien@gmail.com'
 license 'Apache 2.0'
 description 'Provides the mysql2_chef_gem resource'
-version '1.0.2'
+version '1.1.0'
 
 supports 'amazon'
 supports 'redhat'


### PR DESCRIPTION
Relax mysql version constraint for allow recent versions of the cookbook.

Fix https://github.com/sinfomicien/mysql2_chef_gem/issues/9