### PR TITLE
Limit mysql dependency version to < 8.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ supports 'ubuntu'
 supports 'oracle'
 
 depends 'build-essential'
-depends 'mysql', '>= 6.0'
+depends 'mysql', '< 8.0'
 depends 'mariadb'
 
 source_url 'https://github.com/sinfomicien/mysql2_chef_gem' if respond_to?(:source_url)


### PR DESCRIPTION
Limit `mysql` cookbook dependency to  version `< 8.0` - otherwise things are miserably failing.

There are certain incompatibilities with `mysql` recipe v `8.x`. The existing `mysql` dependency is `>= 6.0` which by default pulls the latest 8.x cookbook and makes things to fail.
