### PR TITLE
Chef 12 deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,13 +19,13 @@ group :kitchen_vagrant do
 end
 
 group :development do
-  gem 'ruby_gntp'
   gem 'growl'
-  gem 'rb-fsevent'
   gem 'guard', '~> 2.4'
-  gem 'guard-kitchen'
   gem 'guard-foodcritic'
+  gem 'guard-kitchen'
   gem 'guard-rspec'
   gem 'guard-rubocop'
   gem 'rake'
+  gem 'rb-fsevent'
+  gem 'ruby_gntp'
 end

--- a/libraries/z_provider_mapping.rb
+++ b/libraries/z_provider_mapping.rb
@@ -1,17 +1,19 @@
 #########
 # mysql2_chef_gem
 #########
-Chef::Platform.set platform: :amazon, resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :centos, version: '< 7.0', resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :centos, version: '>= 7.0', resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :debian, resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :fedora, version: '< 19', resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :fedora, version: '>= 19', resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :omnios, resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :redhat, version: '< 7.0', resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :redhat, version: '>= 7.0', resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :scientific, version: '< 7.0', resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :scientific, version: '>= 7.0', resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :smartos, resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :suse, resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
-Chef::Platform.set platform: :ubuntu, resource: :mysql2_chef_gem, provider: Chef::Provider::Mysql2ChefGem::Mysql
+class Chef::Provider::Mysql2ChefGem::Mysql
+  provides :mysql2_chef_gem, platform: 'amazon'
+  provides :mysql2_chef_gem, platform: 'centos', platform_version: '< 7.0'
+  provides :mysql2_chef_gem, platform: 'centos', platform_version: '>= 7.0'
+  provides :mysql2_chef_gem, platform: 'debian'
+  provides :mysql2_chef_gem, platform: 'fedora', platform_version: '< 19'
+  provides :mysql2_chef_gem, platform: 'fedora', platform_version: '>= 19'
+  provides :mysql2_chef_gem, platform: 'omnios'
+  provides :mysql2_chef_gem, platform: 'redhat', platform_version: '< 6.0'
+  provides :mysql2_chef_gem, platform: 'redhat', platform_version: '>= 7.0'
+  provides :mysql2_chef_gem, platform: 'scientific', platform_version: '< 7.0'
+  provides :mysql2_chef_gem, platform: 'scientific', platform_version: '>= 7.0'
+  provides :mysql2_chef_gem, platform: 'smartos'
+  provides :mysql2_chef_gem, platform: 'suse'
+  provides :mysql2_chef_gem, platform: 'ubuntu'
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sinfomicien@gmail.com'
 license 'Apache 2.0'
 description 'Provides the mysql2_chef_gem resource'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.0'
+version '1.1.1'
 
 supports 'amazon'
 supports 'redhat'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'mysql2_chef_gem_test::default' do
   let(:chef_run) do
     ChefSpec::ServerRunner.new do |node|
-      node.set['mysql2_chef_gem']['resource_name'] = 'default'
+      node.default['mysql2_chef_gem']['resource_name'] = 'default'
     end.converge('mysql2_chef_gem_test::default')
   end
 


### PR DESCRIPTION
Replaced calls to methods that have been deprecated in Chef 12. These will become hard errors in Chef 13.