### PR TITLE
Add matcher for mysql2_chef_gem_mariadb

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -2,4 +2,8 @@ if defined?(ChefSpec)
   def install_mysql2_chef_gem(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:mysql2_chef_gem, :install, resource_name)
   end
+
+  def install_mysql2_chef_gem_mariadb(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:mysql2_chef_gem_mariadb, :install, resource_name)
+  end
 end


### PR DESCRIPTION
Adds a matcher for the `mysql2_chef_gem_mariadb` resource.